### PR TITLE
parameterized query: add parameterized query to stmt.Query

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ prq "presto://example:8080/hive/default" "SHOW TABLES"
 * `varchar`, `bigint`, `boolean`, `double` and `timestamp` datatypes
 * Custom HTTP clients
 
-## Future 
+## Future
 
 (aka: Things you could help with)
 
@@ -99,20 +99,19 @@ Originally written by [Ian Davis](http://iandavis.com).
 
 ## Contributors
 
-Your name here...
+Allan Liu
 
 ## Contributing
 
 * Do submit your changes as a pull request
 * Do your best to adhere to the existing coding conventions and idioms.
 * Do supply unit tests if possible.
-* Do run `go fmt` on the code before committing 
+* Do run `go fmt` on the code before committing
 * Do feel free to add yourself to the Contributors list in
   the [`README.md`](README.md).  Alphabetical order applies.
-* Don't touch the Authors section. An existing author will add you if 
+* Don't touch the Authors section. An existing author will add you if
   your contributions are significant enough.
 
 ## License
 
 This software is released under the MIT License, please see the accompanying [`LICENSE`](LICENSE) file.
-

--- a/conn.go
+++ b/conn.go
@@ -85,8 +85,9 @@ var _ driver.Conn = &conn{}
 
 func (c *conn) Prepare(query string) (driver.Stmt, error) {
 	st := &stmt{
-		conn:  c,
-		query: query,
+		conn:         c,
+		query:        query,
+		paramOffsets: getParameterOffsets(query),
 	}
 	return st, nil
 }
@@ -97,71 +98,6 @@ func (c *conn) Close() error {
 
 func (c *conn) Begin() (driver.Tx, error) {
 	return nil, ErrNotSupported
-}
-
-type stmt struct {
-	conn  *conn
-	query string
-}
-
-var _ driver.Stmt = &stmt{}
-
-func (s *stmt) Close() error {
-	return nil
-}
-
-func (s *stmt) NumInput() int {
-	return -1 // TODO: parse query for parameters
-}
-
-func (s *stmt) Exec(args []driver.Value) (driver.Result, error) {
-	return nil, ErrNotSupported
-}
-
-func (s *stmt) Query(args []driver.Value) (driver.Rows, error) {
-	// TODO: support query argument substitution
-	if len(args) > 0 {
-		return nil, ErrNotSupported
-	}
-	queryURL := fmt.Sprintf("http://%s/v1/statement", s.conn.addr)
-
-	req, err := http.NewRequest("POST", queryURL, strings.NewReader(s.query))
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Add("X-Presto-User", s.conn.user)
-	req.Header.Add("X-Presto-Catalog", s.conn.catalog)
-	req.Header.Add("X-Presto-Schema", s.conn.schema)
-
-	resp, err := s.conn.client.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	// Presto doesn't use the http response code, parse errors come back as 200
-	if resp.StatusCode != 200 {
-		return nil, ErrQueryFailed
-	}
-
-	var sresp stmtResponse
-	err = json.NewDecoder(resp.Body).Decode(&sresp)
-	if err != nil {
-		return nil, err
-	}
-
-	if sresp.Stats.State == "FAILED" {
-		return nil, sresp.Error
-	}
-
-	time.Sleep(500 * time.Millisecond)
-
-	r := &rows{
-		conn:    s.conn,
-		nextURI: sresp.NextURI,
-	}
-
-	return r, nil
 }
 
 type rows struct {

--- a/stmt.go
+++ b/stmt.go
@@ -1,0 +1,207 @@
+package prestgo
+
+import (
+	"bytes"
+	"database/sql/driver"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type stmt struct {
+	conn         *conn
+	query        string
+	paramOffsets []int
+}
+
+var _ driver.Stmt = &stmt{}
+
+func (s *stmt) Close() error {
+	return nil
+}
+
+func (s *stmt) NumInput() int {
+	return -1 // TODO: parse query for parameters
+}
+
+func (s *stmt) Exec(args []driver.Value) (driver.Result, error) {
+	return nil, ErrNotSupported
+}
+
+func (s *stmt) Query(args []driver.Value) (driver.Rows, error) {
+	queryURL := fmt.Sprintf("http://%s/v1/statement", s.conn.addr)
+
+	q, err := s.queryInterpolate(args)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL, strings.NewReader(q))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("X-Presto-User", s.conn.user)
+	req.Header.Add("X-Presto-Catalog", s.conn.catalog)
+	req.Header.Add("X-Presto-Schema", s.conn.schema)
+
+	resp, err := s.conn.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	// Presto doesn't use the http response code, parse errors come back as 200
+	if resp.StatusCode != 200 {
+		return nil, ErrQueryFailed
+	}
+
+	var sresp stmtResponse
+	err = json.NewDecoder(resp.Body).Decode(&sresp)
+	if err != nil {
+		return nil, err
+	}
+
+	if sresp.Stats.State == "FAILED" {
+		return nil, sresp.Error
+	}
+
+	time.Sleep(500 * time.Millisecond)
+
+	r := &rows{
+		conn:    s.conn,
+		nextURI: sresp.NextURI,
+	}
+
+	return r, nil
+}
+
+func (s *stmt) queryInterpolate(args []driver.Value) (string, error) {
+	if len(args) != len(s.paramOffsets) {
+		return "", driver.ErrSkip
+	}
+
+	if len(s.paramOffsets) < 1 {
+		return s.query, nil
+	}
+
+	var (
+		result = new(bytes.Buffer)
+		i      = 0
+	)
+
+	for n, arg := range args {
+		result.WriteString(s.query[i:s.paramOffsets[n]])
+
+		switch v := arg.(type) {
+		case string:
+			result.WriteByte('\'')
+			escapeStringBackslash(result, v)
+			result.WriteByte('\'')
+
+		case int64:
+			result.WriteString(strconv.FormatInt(v, 10))
+
+		case float64:
+			result.WriteString(strconv.FormatFloat(v, 'g', -1, 64))
+
+		case bool:
+			if v {
+				result.WriteByte('1')
+			} else {
+				result.WriteByte('0')
+			}
+
+		case nil:
+			result.WriteString("NULL")
+
+		case []byte:
+			if v == nil {
+				result.WriteString("NULL")
+
+			} else {
+				result.WriteString("_binary'")
+				escapeBytesBackslash(result, v)
+				result.WriteByte('\'')
+			}
+
+		case time.Time:
+			if v.IsZero() {
+				result.WriteString("'0000-00-00'")
+
+			} else {
+				v := v.In(time.UTC)
+				v = v.Add(time.Nanosecond * 500) // To round under microsecond
+				year := v.Year()
+				year100 := year / 100
+				year1 := year % 100
+				month := v.Month()
+				day := v.Day()
+				hour := v.Hour()
+				minute := v.Minute()
+				second := v.Second()
+				micro := v.Nanosecond() / 1000
+
+				result.Write([]byte{
+					'\'',
+					digits10[year100], digits01[year100],
+					digits10[year1], digits01[year1],
+					'-',
+					digits10[month], digits01[month],
+					'-',
+					digits10[day], digits01[day],
+					' ',
+					digits10[hour], digits01[hour],
+					':',
+					digits10[minute], digits01[minute],
+					':',
+					digits10[second], digits01[second],
+				})
+
+				if micro != 0 {
+					micro10000 := micro / 10000
+					micro100 := micro / 100 % 100
+					micro1 := micro % 100
+
+					result.Write([]byte{
+						'.',
+						digits10[micro10000], digits01[micro10000],
+						digits10[micro100], digits01[micro100],
+						digits10[micro1], digits01[micro1],
+					})
+				}
+				result.WriteByte('\'')
+			}
+
+		default:
+			return "", driver.ErrSkip
+		}
+
+		i = (s.paramOffsets[n] + 1)
+	}
+
+	if i < len(s.query) {
+		result.WriteString(s.query[i:])
+	}
+
+	return result.String(), nil
+}
+
+func getParameterOffsets(query string) []int {
+	var offsets []int
+
+	for i := 0; i < len(query); {
+		// keep looking for offsets
+		pi := strings.Index(query[i:], "?")
+		if pi == -1 {
+			return offsets
+		}
+		offsets = append(offsets, pi+i)
+
+		i += (pi + 1)
+	}
+
+	return offsets
+}

--- a/stmt_test.go
+++ b/stmt_test.go
@@ -1,0 +1,244 @@
+package prestgo
+
+import (
+	"database/sql/driver"
+	"testing"
+	"time"
+)
+
+func TestGetParameterOffset(t *testing.T) {
+	var tests = []struct {
+		name          string
+		desc          string
+		query         string
+		expectedCount int
+	}{
+		{
+			name:          "a",
+			desc:          "1 query param at the end",
+			query:         "SELECT * FROM abc WHERE blah = ?",
+			expectedCount: 1,
+		},
+		{
+			name:          "b",
+			desc:          "6 query param at the end",
+			query:         "SELECT * FROM abc WHERE blah = ? and foo = ? and bar = ? or (hello = ? and world= ?) or do = ?",
+			expectedCount: 6,
+		},
+		{
+			name: "c",
+			desc: "1 query param with lots of suffixing clauses",
+			query: `SELECT   abc,
+         def,
+         ghi,
+         jkl,
+         mno,
+         pqr,
+         sto,
+         uvw,
+         xyz,
+         abc_def,
+         ghi_ppp,
+         Max(timestamp)
+FROM     hive.infra.fp_system
+WHERE    host = ?
+GROUP BY (abc, def, ghi, jkl, mno, pqr, sto, uvw, xyz, abc_def, ghi_ppp)`,
+			expectedCount: 1,
+		},
+		{
+			name:          "d",
+			desc:          "0 query params",
+			query:         "SELECT * FROM abc",
+			expectedCount: 0,
+		},
+	}
+
+	for i, test := range tests {
+		t.Logf("test %d: %q", i, test.desc)
+
+		t.Run(test.name, func(t *testing.T) {
+			offsets := getParameterOffsets(test.query)
+
+			if len(offsets) != test.expectedCount {
+				t.Fatalf(
+					"getParameterOffsets(%q) -> expected count of %d, got %d",
+					test.query,
+					test.expectedCount,
+					len(offsets),
+				)
+			}
+
+			for _, offset := range offsets {
+				if test.query[offset] != '?' {
+					t.Errorf(
+						"getParameterOffsets(%q) -> expected offset %d to be '?' but got %q",
+						test.query,
+						offset,
+						test.query[offset],
+					)
+				}
+			}
+		})
+	}
+}
+
+func TestQueryInterpolate(t *testing.T) {
+	var happPathTests = []struct {
+		name           string
+		desc           string
+		inputQuery     string
+		queryArgs      []driver.Value
+		expectedOutput string
+	}{
+		{
+			name:           "a",
+			desc:           "1 query param of type string",
+			inputQuery:     "SELECT * FROM abc WHERE blah = ?",
+			queryArgs:      []driver.Value{"def"},
+			expectedOutput: "SELECT * FROM abc WHERE blah = 'def'",
+		},
+		{
+			name:           "b",
+			desc:           "1 query param of type int64",
+			inputQuery:     "SELECT * FROM abc WHERE blah = ?",
+			queryArgs:      []driver.Value{int64(1)},
+			expectedOutput: "SELECT * FROM abc WHERE blah = 1",
+		},
+		{
+			name:           "c",
+			desc:           "1 query param of type bool true",
+			inputQuery:     "SELECT * FROM abc WHERE blah = ?",
+			queryArgs:      []driver.Value{true},
+			expectedOutput: "SELECT * FROM abc WHERE blah = 1",
+		},
+		{
+			name:           "d",
+			desc:           "1 query param of type bool false",
+			inputQuery:     "SELECT * FROM abc WHERE blah = ?",
+			queryArgs:      []driver.Value{false},
+			expectedOutput: "SELECT * FROM abc WHERE blah = 0",
+		},
+		{
+			name:           "e",
+			desc:           "1 query param of type float64",
+			inputQuery:     "SELECT * FROM abc WHERE blah = ?",
+			queryArgs:      []driver.Value{float64(1.01)},
+			expectedOutput: "SELECT * FROM abc WHERE blah = 1.01",
+		},
+		{
+			name:           "f",
+			desc:           "1 query param of type []byte",
+			inputQuery:     "SELECT * FROM abc WHERE blah = ?",
+			queryArgs:      []driver.Value{[]byte("abcdef")},
+			expectedOutput: "SELECT * FROM abc WHERE blah = _binary'abcdef'",
+		},
+		{
+			name:           "g",
+			desc:           "1 query param of type nil",
+			inputQuery:     "SELECT * FROM abc WHERE blah = ?",
+			queryArgs:      []driver.Value{nil},
+			expectedOutput: "SELECT * FROM abc WHERE blah = NULL",
+		},
+		{
+			name:           "h",
+			desc:           "1 query param of type time.Time",
+			inputQuery:     "SELECT * FROM abc WHERE blah = ?",
+			queryArgs:      []driver.Value{time.Date(1990, time.May, 1, 1, 1, 1, 1, time.UTC)},
+			expectedOutput: "SELECT * FROM abc WHERE blah = '1990-05-01 01:01:01'",
+		},
+		{
+			name:           "i",
+			desc:           "3 query param of type string, int64, and time.Time",
+			inputQuery:     "SELECT * FROM abc WHERE foo = ? and bar = ? and blah = ?",
+			queryArgs:      []driver.Value{"abc", int64(5), time.Date(1990, time.May, 1, 1, 1, 1, 1, time.UTC)},
+			expectedOutput: "SELECT * FROM abc WHERE foo = 'abc' and bar = 5 and blah = '1990-05-01 01:01:01'",
+		},
+		{
+			name:           "j",
+			desc:           "0 query params",
+			inputQuery:     "SELECT * FROM abc WHERE blah",
+			queryArgs:      []driver.Value{},
+			expectedOutput: "SELECT * FROM abc WHERE blah",
+		},
+		{
+			name:           "k",
+			desc:           "1 query param of type string",
+			inputQuery:     "SELECT * FROM abc WHERE blah = ?",
+			queryArgs:      []driver.Value{"def\r\n'"},
+			expectedOutput: "SELECT * FROM abc WHERE blah = 'def\\r\\n\\''",
+		},
+	}
+
+	for i, test := range happPathTests {
+		t.Logf("happy path test %d: %q", i, test.desc)
+
+		t.Run(test.name, func(t *testing.T) {
+			s := &stmt{
+				query:        test.inputQuery,
+				paramOffsets: getParameterOffsets(test.inputQuery),
+			}
+
+			got, err := s.queryInterpolate(test.queryArgs)
+			if err != nil {
+				t.Fatalf(
+					"stmt.queryInterpolate(%v) -> error: %v; expected nil",
+					test.queryArgs,
+					err,
+				)
+			}
+
+			if got != test.expectedOutput {
+				t.Errorf(
+					"stmt.queryInterpolate(%v) -> %q; expected %q",
+					test.queryArgs,
+					got,
+					test.expectedOutput,
+				)
+			}
+		})
+	}
+
+	var negativeTests = []struct {
+		name       string
+		desc       string
+		inputQuery string
+		queryArgs  []driver.Value
+	}{
+		{
+			name:       "a",
+			desc:       "arg count is less than offset count",
+			inputQuery: "SELECT * FROM abc WHERE blah = ?",
+			queryArgs:  []driver.Value{},
+		},
+		{
+			name:       "b",
+			desc:       "arg count is greater than offset count",
+			inputQuery: "SELECT * FROM abc WHERE blah = ?",
+			queryArgs:  []driver.Value{"def", "efg"},
+		},
+		{
+			name:       "c",
+			desc:       "invalid arg type",
+			inputQuery: "SELECT * FROM abc WHERE blah = ?",
+			queryArgs:  []driver.Value{8},
+		},
+	}
+
+	for i, test := range negativeTests {
+		t.Logf("negative path test %d: %q", i, test.desc)
+
+		t.Run(test.name, func(t *testing.T) {
+			s := &stmt{
+				query:        test.inputQuery,
+				paramOffsets: getParameterOffsets(test.inputQuery),
+			}
+
+			if _, err := s.queryInterpolate(test.queryArgs); err == nil {
+				t.Errorf(
+					"stmt.queryInterpolate(%v) -> nil error; expected and error",
+					test.queryArgs,
+				)
+			}
+		})
+	}
+}

--- a/stmt_test.go
+++ b/stmt_test.go
@@ -56,29 +56,28 @@ GROUP BY (abc, def, ghi, jkl, mno, pqr, sto, uvw, xyz, abc_def, ghi_ppp)`,
 	for i, test := range tests {
 		t.Logf("test %d: %q", i, test.desc)
 
-		t.Run(test.name, func(t *testing.T) {
-			offsets := getParameterOffsets(test.query)
+		offsets := getParameterOffsets(test.query)
 
-			if len(offsets) != test.expectedCount {
-				t.Fatalf(
-					"getParameterOffsets(%q) -> expected count of %d, got %d",
+		if len(offsets) != test.expectedCount {
+			t.Fatalf(
+				"getParameterOffsets(%q) -> expected count of %d, got %d",
+				test.query,
+				test.expectedCount,
+				len(offsets),
+			)
+		}
+
+		for _, offset := range offsets {
+			if test.query[offset] != '?' {
+				t.Errorf(
+					"getParameterOffsets(%q) -> expected offset %d to be '?' but got %q",
 					test.query,
-					test.expectedCount,
-					len(offsets),
+					offset,
+					test.query[offset],
 				)
 			}
+		}
 
-			for _, offset := range offsets {
-				if test.query[offset] != '?' {
-					t.Errorf(
-						"getParameterOffsets(%q) -> expected offset %d to be '?' but got %q",
-						test.query,
-						offset,
-						test.query[offset],
-					)
-				}
-			}
-		})
 	}
 }
 
@@ -172,30 +171,29 @@ func TestQueryInterpolate(t *testing.T) {
 	for i, test := range happPathTests {
 		t.Logf("happy path test %d: %q", i, test.desc)
 
-		t.Run(test.name, func(t *testing.T) {
-			s := &stmt{
-				query:        test.inputQuery,
-				paramOffsets: getParameterOffsets(test.inputQuery),
-			}
+		s := &stmt{
+			query:        test.inputQuery,
+			paramOffsets: getParameterOffsets(test.inputQuery),
+		}
 
-			got, err := s.queryInterpolate(test.queryArgs)
-			if err != nil {
-				t.Fatalf(
-					"stmt.queryInterpolate(%v) -> error: %v; expected nil",
-					test.queryArgs,
-					err,
-				)
-			}
+		got, err := s.queryInterpolate(test.queryArgs)
+		if err != nil {
+			t.Fatalf(
+				"stmt.queryInterpolate(%v) -> error: %v; expected nil",
+				test.queryArgs,
+				err,
+			)
+		}
 
-			if got != test.expectedOutput {
-				t.Errorf(
-					"stmt.queryInterpolate(%v) -> %q; expected %q",
-					test.queryArgs,
-					got,
-					test.expectedOutput,
-				)
-			}
-		})
+		if got != test.expectedOutput {
+			t.Errorf(
+				"stmt.queryInterpolate(%v) -> %q; expected %q",
+				test.queryArgs,
+				got,
+				test.expectedOutput,
+			)
+		}
+
 	}
 
 	var negativeTests = []struct {
@@ -227,18 +225,17 @@ func TestQueryInterpolate(t *testing.T) {
 	for i, test := range negativeTests {
 		t.Logf("negative path test %d: %q", i, test.desc)
 
-		t.Run(test.name, func(t *testing.T) {
-			s := &stmt{
-				query:        test.inputQuery,
-				paramOffsets: getParameterOffsets(test.inputQuery),
-			}
+		s := &stmt{
+			query:        test.inputQuery,
+			paramOffsets: getParameterOffsets(test.inputQuery),
+		}
 
-			if _, err := s.queryInterpolate(test.queryArgs); err == nil {
-				t.Errorf(
-					"stmt.queryInterpolate(%v) -> nil error; expected and error",
-					test.queryArgs,
-				)
-			}
-		})
+		if _, err := s.queryInterpolate(test.queryArgs); err == nil {
+			t.Errorf(
+				"stmt.queryInterpolate(%v) -> nil error; expected and error",
+				test.queryArgs,
+			)
+		}
+
 	}
 }

--- a/types.go
+++ b/types.go
@@ -37,6 +37,9 @@ const (
 	// Instant in time that includes the date and time of day with a time zone. Values of this type are parsed and rendered in the provided time zone.
 	// Example: TIMESTAMP '2001-08-22 03:04:05.321' AT TIME ZONE 'America/Los_Angeles'
 	TimestampWithTimezone = "timestamp with time zone"
+
+	digits01 = "0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"
+	digits10 = "0000000000111111111122222222223333333333444444444455555555556666666666777777777788888888889999999999"
 )
 
 type stmtResponse struct {

--- a/utils.go
+++ b/utils.go
@@ -1,0 +1,65 @@
+package prestgo
+
+import "bytes"
+
+// escapeBytesBackslash escapes []byte with backslashes (\)
+func escapeBytesBackslash(buf *bytes.Buffer, v []byte) {
+	for _, c := range v {
+		switch c {
+		case '\x00':
+			buf.Write([]byte{'\\', '0'})
+
+		case '\n':
+			buf.Write([]byte{'\\', 'n'})
+
+		case '\r':
+			buf.Write([]byte{'\\', 'r'})
+
+		case '\x1a':
+			buf.Write([]byte{'\\', 'Z'})
+
+		case '\'':
+			buf.Write([]byte{'\\', '\''})
+
+		case '"':
+			buf.Write([]byte{'\\', '"'})
+
+		case '\\':
+			buf.Write([]byte{'\\', '\\'})
+
+		default:
+			buf.WriteByte(c)
+		}
+	}
+}
+
+// escapeStringBackslash is similar to escapeBytesBackslash but for string.
+func escapeStringBackslash(buf *bytes.Buffer, v string) {
+	for i := 0; i < len(v); i++ {
+		switch v[i] {
+		case '\x00':
+			buf.Write([]byte{'\\', '0'})
+
+		case '\n':
+			buf.Write([]byte{'\\', 'n'})
+
+		case '\r':
+			buf.Write([]byte{'\\', 'r'})
+
+		case '\x1a':
+			buf.Write([]byte{'\\', 'Z'})
+
+		case '\'':
+			buf.Write([]byte{'\\', '\''})
+
+		case '"':
+			buf.Write([]byte{'\\', '"'})
+
+		case '\\':
+			buf.Write([]byte{'\\', '\\'})
+
+		default:
+			buf.WriteByte(v[i])
+		}
+	}
+}


### PR DESCRIPTION
- Added interpolateQuery function for generating query utilizing parameterized queries
- Moved the stmt stuff in conn.go into its own file since there's more and more stmt specific stuff --hope you don't mind :)
- Defaulting timezone to UTC for now; will send a separate PR that extracts that configuration out of the DSN
- Copied how the mysql driver was handling string escapes and time format handling for the interim (we're currently not utilizing those types right now)
