### PR TITLE
JSON should be decoded with json.Number

### DIFF
--- a/conn_test.go
+++ b/conn_test.go
@@ -2,6 +2,7 @@ package prestgo
 
 import (
 	"database/sql/driver"
+	"encoding/json"
 	"fmt"
 	"io"
 	"math"
@@ -414,7 +415,7 @@ func TestDoubleConverter(t *testing.T) {
 	}{
 
 		{
-			val:      0.91,
+			val:      json.Number("0.91"),
 			expected: driver.Value(0.91),
 			err:      false,
 		},
@@ -479,7 +480,7 @@ func TestBigIntConverter(t *testing.T) {
 	}{
 
 		{
-			val:      1000.0,
+			val:      json.Number("1000"),
 			expected: driver.Value(int64(1000)),
 			err:      false,
 		},


### PR DESCRIPTION
Hi, thanks for the library! I'm submitting a fix for bigint values so that they won't be subject to floating point errors when decoded from JSON. As a trivial example:

```
func main() {
	f := float64(803311065327869963)
	i := int64(f)
	fmt.Println(f) // 8.0331106532787e+17
	fmt.Println(i) // 803311065327869952
}
```

Hope this helps.