### PR TITLE
add covert decimal to string

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1,3 +1,4 @@
+
 package prestgo
 
 import (
@@ -228,7 +229,8 @@ func (r *rows) fetch() error {
 					r.types[i] = varbinaryConverter
 				case col.Type == ArrayVarchar:
 					r.types[i] = arrayVarcharConverter
-
+				case col.Type == decimal:
+					r.types[i] = decimalVarcharConverter
 				default:
 					return fmt.Errorf("unsupported column type: %s", col.Type)
 				}
@@ -504,4 +506,14 @@ var arrayVarcharConverter = valueConverterFunc(func(val interface{}) (driver.Val
 	}
 
 	return nil, fmt.Errorf("%s: failed to convert %v (%T) into type []string", DriverName, val, val)
+})
+var decimalVarcharConverter = valueConverterFunc(func(val interface{} )(driver.Value, error){
+	if val == nil {
+		return nil, nil
+	}
+	if value, ok := val.(string); ok {
+		return value, nil
+	}
+
+	return nil, fmt.Errorf("%s: failed to convert %v (%T) into type string", DriverName, val, val)
 })

--- a/types.go
+++ b/types.go
@@ -43,6 +43,7 @@ const (
 
 	// Array of variable length character data.
 	ArrayVarchar = "array(varchar)"
+	decimal = "decimal(19,6)"
 )
 
 type stmtResponse struct {


### PR DESCRIPTION
When I use the presto read data from hive, I found presto-go-client can not convert decimal type of data, then I added the type of decimal conversion same as the way of your  source , converted decimal to string, so that the user according to Its own needs to convert it to float64 or other types.